### PR TITLE
fix array index out of bound when parsing output and avg daemon handling improvements

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -151,7 +151,12 @@ func ParseAVGOutput(avgout string, err error, path string) ResultsData {
 			}
 			if strings.Contains(line, path) {
 				pathVirusString := strings.Split(line, "  ")
-				avg.Result = strings.TrimSpace(pathVirusString[1])
+				if len(pathVirusString) >= 2 {
+					avg.Result = strings.TrimSpace(pathVirusString[1])
+				} else {
+					log.Error("[ERROR] could not extract virus string from pathVirusString.")
+					log.Errorf("[ERROR] pathVirusString was: \n%s", pathVirusString)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
it's me again :)

- fixing potential array index out of bounds in parseavgoutput. happened rarely, but happened. This way, at least the container won't crash anymore.
- enhance daemon restart handling: There's a potential race condition when using the web API to access the container. Calling the API several times in parallel with the daemon currently being down could result in multiple daemon restarts (each request thinks he has to restart the daemon) what in return messes up the reports of the other scans as the daemon terminates while scanning.